### PR TITLE
FAVCS-40: Added style for removing whole footer from print version

### DIFF
--- a/docroot/profiles/favrskov/themes/favrskovtheme/sass/print.scss
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/sass/print.scss
@@ -141,3 +141,10 @@ object,
     display: none;
 }
 
+@media print {
+  /* line 147, ../sass/print.scss */
+  .footer-block, .footer-block * {
+    display: none !important;
+  }
+}
+


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-40
  
### Changes
- Exclude footer from print version
  
### Technical Details
- Added style to exclude footer from print version
  
### Affected Pages
- All nodes
  
### Key Affected Code
- print.scss
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- Go to favrskov theme folder and 'compass compile'
- Flush css and js cache