### PR TITLE
FAVCS-41: Link style underline

### DIFF
--- a/docroot/profiles/favrskov/themes/favrskovtheme/sass/pages/_articles.scss
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/sass/pages/_articles.scss
@@ -38,3 +38,11 @@
     padding: 0 5px;
   }
 }
+
+#article-body a{
+  text-decoration: underline;
+}
+
+#news-body a{
+  text-decoration: underline;
+}

--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/nodes/field--body--article.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/nodes/field--body--article.tpl.php
@@ -1,0 +1,4 @@
+<section id="article-body" class="node-body group">
+  <?php print render($items); ?>
+</section>
+

--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/nodes/field--body--news.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/nodes/field--body--news.tpl.php
@@ -1,0 +1,4 @@
+<section id="news-body" class="node-body group">
+  <?php print render($items); ?>
+</section>
+


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-41
  
### Changes
- Add underline to all links in the body of node types articles and news
  
### Technical Details
- Added custom template for node type news body field
- Added custom template for node type article body field
- Added style for link underline 
  
### Affected Pages
- Article Nodes
- News Nodes
  
### Key Affected Code
- N/A
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- compile sass
- drush cc all