### PR TITLE
FAVCS-58: Change size on images in publications

### DIFF
--- a/docroot/profiles/favrskov/modules/custom/favrskov_helper/favrskov_helper.install
+++ b/docroot/profiles/favrskov/modules/custom/favrskov_helper/favrskov_helper.install
@@ -994,3 +994,11 @@ function favrskov_helper_update_7054() {
     ->condition('type', 'module')
     ->execute();
 }
+
+/**
+ * Implements hook_update_7055
+ * Revert feature 'media_imagestyles'.
+ */
+function favrskov_helper_update_7055() {
+  features_revert_module('media_imagestyles');
+}

--- a/docroot/profiles/favrskov/modules/features/other/media_imagestyles/media_imagestyles.features.inc
+++ b/docroot/profiles/favrskov/modules/features/other/media_imagestyles/media_imagestyles.features.inc
@@ -12,17 +12,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: banners_custom_user_full_1x.
   $styles['banners_custom_user_full_1x'] = array(
-    'name' => 'banners_custom_user_full_1x',
     'label' => 'banners_custom_user_full_1x',
     'effects' => array(
       1 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 315,
@@ -35,16 +27,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: banners_custom_user_phone_1x.
   $styles['banners_custom_user_phone_1x'] = array(
-    'name' => 'banners_custom_user_phone_1x',
     'effects' => array(
       44 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 480,
@@ -58,16 +42,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: banners_custom_user_phone_land_1x.
   $styles['banners_custom_user_phone_land_1x'] = array(
-    'name' => 'banners_custom_user_phone_land_1x',
     'effects' => array(
       46 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 705,
@@ -81,16 +57,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: banners_custom_user_phone_port_1x.
   $styles['banners_custom_user_phone_port_1x'] = array(
-    'name' => 'banners_custom_user_phone_port_1x',
     'effects' => array(
       45 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 317,
@@ -104,16 +72,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: banners_custom_user_tablet_1x.
   $styles['banners_custom_user_tablet_1x'] = array(
-    'name' => 'banners_custom_user_tablet_1x',
     'effects' => array(
       47 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 705,
@@ -127,17 +87,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: blog_teaser.
   $styles['blog_teaser'] = array(
-    'name' => 'blog_teaser',
     'label' => 'blog_teaser',
     'effects' => array(
       7 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 565,
@@ -150,17 +102,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: blogcustom_user_phone_1x.
   $styles['blogcustom_user_phone_1x'] = array(
-    'name' => 'blogcustom_user_phone_1x',
     'label' => 'blogcustom_user_phone_1x',
     'effects' => array(
       3 => array(
-        'label' => 'Scale',
-        'help' => 'Scaling will maintain the aspect-ratio of the original image. If only a single dimension is specified, the other dimension will be calculated.',
-        'effect callback' => 'image_scale_effect',
-        'dimensions callback' => 'image_scale_dimensions',
-        'form callback' => 'image_scale_form',
-        'summary theme' => 'image_scale_summary',
-        'module' => 'image',
         'name' => 'image_scale',
         'data' => array(
           'width' => 380,
@@ -174,17 +118,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: blogcustom_user_phone_land_1x.
   $styles['blogcustom_user_phone_land_1x'] = array(
-    'name' => 'blogcustom_user_phone_land_1x',
     'label' => 'blogcustom_user_phone_land_1x',
     'effects' => array(
       5 => array(
-        'label' => 'Scale',
-        'help' => 'Scaling will maintain the aspect-ratio of the original image. If only a single dimension is specified, the other dimension will be calculated.',
-        'effect callback' => 'image_scale_effect',
-        'dimensions callback' => 'image_scale_dimensions',
-        'form callback' => 'image_scale_form',
-        'summary theme' => 'image_scale_summary',
-        'module' => 'image',
         'name' => 'image_scale',
         'data' => array(
           'width' => 480,
@@ -198,16 +134,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: blogcustom_user_phone_port_1x.
   $styles['blogcustom_user_phone_port_1x'] = array(
-    'name' => 'blogcustom_user_phone_port_1x',
     'effects' => array(
       7 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 566,
@@ -221,16 +149,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: blogcustom_user_tablet_1x.
   $styles['blogcustom_user_tablet_1x'] = array(
-    'name' => 'blogcustom_user_tablet_1x',
     'effects' => array(
       4 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 767,
@@ -244,17 +164,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: faktaboks_image.
   $styles['faktaboks_image'] = array(
-    'name' => 'faktaboks_image',
     'label' => 'faktaboks_image',
     'effects' => array(
       1 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 120,
@@ -267,16 +179,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: newsletter.
   $styles['newsletter'] = array(
-    'name' => 'newsletter',
     'effects' => array(
       2 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 666,
@@ -290,16 +194,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: newsletter_news.
   $styles['newsletter_news'] = array(
-    'name' => 'newsletter_news',
     'effects' => array(
       1 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 316,
@@ -313,16 +209,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: node_slide.
   $styles['node_slide'] = array(
-    'name' => 'node_slide',
     'effects' => array(
       3 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 566,
@@ -336,23 +224,29 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: picture.
   $styles['picture'] = array(
-    'name' => 'picture',
     'effects' => array(),
     'label' => 'picture',
   );
 
+  // Exported image style: publications_thumb.
+  $styles['publications_thumb'] = array(
+    'label' => 'Publications thumb',
+    'effects' => array(
+      3 => array(
+        'name' => 'image_scale_and_crop',
+        'data' => array(
+          'width' => 150,
+          'height' => 212,
+        ),
+        'weight' => 2,
+      ),
+    ),
+  );
+
   // Exported image style: slider_default.
   $styles['slider_default'] = array(
-    'name' => 'slider_default',
     'effects' => array(
       6 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 1920,
@@ -366,16 +260,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slider_thumb.
   $styles['slider_thumb'] = array(
-    'name' => 'slider_thumb',
     'effects' => array(
       2 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 109,
@@ -389,17 +275,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slidercustom_user_full_1x.
   $styles['slidercustom_user_full_1x'] = array(
-    'name' => 'slidercustom_user_full_1x',
     'label' => 'slidercustom_user_full_1x',
     'effects' => array(
       2 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 980,
@@ -412,16 +290,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slidercustom_user_phone_1x.
   $styles['slidercustom_user_phone_1x'] = array(
-    'name' => 'slidercustom_user_phone_1x',
     'effects' => array(
       37 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 350,
@@ -435,16 +305,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slidercustom_user_phone_land_1x.
   $styles['slidercustom_user_phone_land_1x'] = array(
-    'name' => 'slidercustom_user_phone_land_1x',
     'effects' => array(
       38 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 768,
@@ -458,16 +320,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slidercustom_user_phone_port_1x.
   $styles['slidercustom_user_phone_port_1x'] = array(
-    'name' => 'slidercustom_user_phone_port_1x',
     'effects' => array(
       42 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 480,
@@ -481,16 +335,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: slidercustom_user_tablet_1x.
   $styles['slidercustom_user_tablet_1x'] = array(
-    'name' => 'slidercustom_user_tablet_1x',
     'effects' => array(
       39 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 980,
@@ -504,17 +350,9 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_full_1x.
   $styles['subject_custom_user_full_1x'] = array(
-    'name' => 'subject_custom_user_full_1x',
     'label' => 'subject_custom_user_full_1x',
     'effects' => array(
       1 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 980,
@@ -527,16 +365,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_phone_1x.
   $styles['subject_custom_user_phone_1x'] = array(
-    'name' => 'subject_custom_user_phone_1x',
     'effects' => array(
       51 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 400,
@@ -550,16 +380,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_phone_land_1x.
   $styles['subject_custom_user_phone_land_1x'] = array(
-    'name' => 'subject_custom_user_phone_land_1x',
     'effects' => array(
       53 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 770,
@@ -573,16 +395,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_phone_port_1x.
   $styles['subject_custom_user_phone_port_1x'] = array(
-    'name' => 'subject_custom_user_phone_port_1x',
     'effects' => array(
       52 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 480,
@@ -596,16 +410,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_slider_default_1x.
   $styles['subject_custom_user_slider_default_1x'] = array(
-    'name' => 'subject_custom_user_slider_default_1x',
     'effects' => array(
       49 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 1920,
@@ -619,16 +425,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_custom_user_tablet_1x.
   $styles['subject_custom_user_tablet_1x'] = array(
-    'name' => 'subject_custom_user_tablet_1x',
     'effects' => array(
       54 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 980,
@@ -642,16 +440,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: subject_image.
   $styles['subject_image'] = array(
-    'name' => 'subject_image',
     'effects' => array(
       48 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 1920,
@@ -665,16 +455,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: thumb_150x120.
   $styles['thumb_150x120'] = array(
-    'name' => 'thumb_150x120',
     'effects' => array(
       1 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 150,
@@ -688,16 +470,8 @@ function media_imagestyles_image_default_styles() {
 
   // Exported image style: videocustom_user_tablet_1x.
   $styles['videocustom_user_tablet_1x'] = array(
-    'name' => 'videocustom_user_tablet_1x',
     'effects' => array(
       17 => array(
-        'label' => 'Scale and crop',
-        'help' => 'Scale and crop will maintain the aspect-ratio of the original image, then crop the larger dimension. This is most useful for creating perfectly square thumbnails without stretching the image.',
-        'effect callback' => 'image_scale_and_crop_effect',
-        'dimensions callback' => 'image_resize_dimensions',
-        'form callback' => 'image_resize_form',
-        'summary theme' => 'image_resize_summary',
-        'module' => 'image',
         'name' => 'image_scale_and_crop',
         'data' => array(
           'width' => 349,

--- a/docroot/profiles/favrskov/modules/features/other/media_imagestyles/media_imagestyles.info
+++ b/docroot/profiles/favrskov/modules/features/other/media_imagestyles/media_imagestyles.info
@@ -1,7 +1,7 @@
 name = Media Imagestyles
 core = 7.x
 package = Media
-version = 7.x-1.0
+version = 7.x-1.1
 project = media_imagestyles
 dependencies[] = image
 features[features_api][] = api:2
@@ -20,6 +20,7 @@ features[image][] = newsletter
 features[image][] = newsletter_news
 features[image][] = node_slide
 features[image][] = picture
+features[image][] = publications_thumb
 features[image][] = slider_default
 features[image][] = slider_thumb
 features[image][] = slidercustom_user_full_1x

--- a/docroot/profiles/favrskov/themes/favrskovtheme/sass/pages/_node.scss
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/sass/pages/_node.scss
@@ -977,7 +977,9 @@
   .decription {
     margin-bottom: 10px;
     line-height: 1.4;
-
+    strong {
+      font-weight: bold;
+    }
     .file a {
       background: url(../images/file.png) no-repeat left center;
     }

--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/publications/field--field-image--field-publications.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/publications/field--field-image--field-publications.tpl.php
@@ -1,4 +1,4 @@
-<?php $items[0]['#image_style'] = 'thumb_150x120' ?>
+<?php $items[0]['#image_style'] = 'publications_thumb' ?>
 <div class="publication-image">
   <?php print render($items); ?>
 </div>


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-58
  
### Changes
- Change images aspect ratio and size in publications
  
### Technical Details
- Changed image style of field_publications
- Modified style for `<strong>` element to be bold in publications description.
- Recreated media_imagestyles feature with the new publications_thumb image style
- Created hook_update to revert media_imagestyles feature after deploy
  
### Affected Pages
- /borger/familie-boern-og-oekonomi/hammel
  
### Key Affected Code
- N/A
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- compile style
- drush updb