### PR TITLE
FAVCS-64: Can not change name on in a contact box

### DIFF
--- a/docroot/profiles/favrskov/modules/features/content_types/content_type_phone_book/content_type_phone_book.module
+++ b/docroot/profiles/favrskov/modules/features/content_types/content_type_phone_book/content_type_phone_book.module
@@ -123,15 +123,3 @@ function content_type_phone_book_check_telephone_number($node, $field_name, $hum
       array('@name' => $human_name)));
   }
 }
-
-/**
- * Implements hook_form_alter().
- *
- * Changing default Address module fields.
- */
-function content_type_phone_book_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id === 'phone_book_node_form') {
-    $form['field_phone_book_address'][LANGUAGE_NONE][0]['name_block']['first_name']['#title'] = t('Name', array(), array('context' => 'phonebook'));
-    $form['field_phone_book_address'][LANGUAGE_NONE][0]['name_block']['last_name']['#access'] = FALSE;
-  }
-}

--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/phone_book/node--phone-book.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/phone_book/node--phone-book.tpl.php
@@ -14,14 +14,10 @@
   'field_phone_book_stuff',
 );
 
-// Throw node url to formatter.
-$content['field_phone_book_address'][0]['name_block']['first_name']['#view_mode'] = $view_mode;
-$content['field_phone_book_address'][0]['name_block']['last_name']['#view_mode'] = $view_mode;
 ?>
 <?php print '<div class="contact-item group">'; ?>
 <div class='contact-info'>
   <?php foreach ($fields as $field): ?>
-
     <?php if (isset($content[$field])): ?>
       <?php print render($content[$field]) ?>
     <?php endif ?>


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-64
  
### Changes
- Remove unwanted "First name" field and leave only the "Full name" field
  
### Technical Details
- Deleted unnecessary code for modification of address field subfields, as the address field subfields can be modified through the Drupal interface
  
### Affected Pages
- content type "phone_book"
  
### Key Affected Code
- N/A
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- N/A