### PR TITLE
FAVCS-79: Drupal security update 

### DIFF
--- a/docroot/profiles/favrskov/modules/contrib/link/link.info
+++ b/docroot/profiles/favrskov/modules/contrib/link/link.info
@@ -18,8 +18,8 @@ files[] = tests/link.validate.test
 files[] = views/link_views_handler_argument_target.inc
 files[] = views/link_views_handler_filter_protocol.inc
 
-; Information added by Drupal.org packaging script on 2018-05-13
-version = "7.x-1.5"
+; Information added by Drupal.org packaging script on 2019-02-20
+version = "7.x-1.6"
 core = "7.x"
 project = "link"
-datestamp = "1526190487"
+datestamp = "1550680687"

--- a/docroot/profiles/favrskov/modules/contrib/link/link.module
+++ b/docroot/profiles/favrskov/modules/contrib/link/link.module
@@ -315,6 +315,16 @@ function link_field_validate($entity_type, $entity, $field, $instance, $langcode
     }
   }
 
+  foreach ($items as $delta => $value) {
+    if (isset($value['attributes']) && is_string($value['attributes'])) {
+      $errors[$field['field_name']][$langcode][$delta][] = array(
+        'error' => 'link_required',
+        'message' => t('String values are not acceptable for attributes.'),
+        'error_element' => array('url' => TRUE, 'title' => FALSE),
+      );
+    }
+  }
+
   if ($instance['settings']['url'] === 'optional' && $instance['settings']['title'] === 'optional' && $instance['required'] && !$optional_field_found) {
     $errors[$field['field_name']][$langcode][0][] = array(
       'error' => 'link_required',


### PR DESCRIPTION
## FAVCS-79: Drupal security update 
  
### Changes
- Perform security Drupal update
  
### Technical Details
- Security update of Link module from version 7.x-1.5 to 7.x-1.6
  
### Affected Pages
- N/A
  
### Key Affected Code
- N/A
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- N/A