### PR TITLE
FAVCS-82: Updates March 2019

### DIFF
--- a/docroot/CHANGELOG.txt
+++ b/docroot/CHANGELOG.txt
@@ -1,3 +1,14 @@
+Drupal 7.xx, xxxx-xx-xx (development version)
+-----------------------
+
+Drupal 7.64, 2019-02-06
+-----------------------
+- [regression] Unset the 'host' header in drupal_http_request() during redirect
+- Fixed: 7.x does not have Phar protection and Phar tests are failing on Drupal 7
+- Fixed: Notice: Undefined index: display_field in file_field_widget_value() (line 582 of /module/file/file.field.inc)
+- Performance improvement: Registry rebuild should not parse the same file twice in the same request
+- Fixed _registry_update() to clear caches after transaction is committed
+
 Drupal 7.63, 2019-01-16
 -----------------------
 - Fixed a fatal error for some Drush users introduced by SA-CORE-2019-002.

--- a/docroot/includes/bootstrap.inc
+++ b/docroot/includes/bootstrap.inc
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '7.63');
+define('VERSION', '7.64');
 
 /**
  * Core API compatibility.

--- a/docroot/includes/common.inc
+++ b/docroot/includes/common.inc
@@ -1094,6 +1094,11 @@ function drupal_http_request($url, array $options = array()) {
       elseif ($options['max_redirects']) {
         // Redirect to the new location.
         $options['max_redirects']--;
+
+        // We need to unset the 'Host' header
+        // as we are redirecting to a new location.
+        unset($options['headers']['Host']);
+
         $result = drupal_http_request($location, $options);
         $result->redirect_code = $code;
       }

--- a/docroot/includes/file.inc
+++ b/docroot/includes/file.inc
@@ -2130,9 +2130,33 @@ function file_download_access($uri) {
  *   'filename', and 'name' members corresponding to the matching files.
  */
 function file_scan_directory($dir, $mask, $options = array(), $depth = 0) {
+  // Default nomask option.
+  $nomask = '/(\.\.?|CVS)$/';
+
+  // Overrides the $nomask variable accordingly if $options['nomask'] is set.
+  //
+  // Allow directories specified in settings.php to be ignored. You can use this
+  // to not check for files in common special-purpose directories. For example,
+  // node_modules and bower_components. Ignoring irrelevant directories is a
+  // performance boost.
+  if (!isset($options['nomask'])) {
+    $ignore_directories = variable_get(
+      'file_scan_ignore_directories',
+      array()
+    );
+
+    foreach ($ignore_directories as $index => $ignore_directory) {
+      $ignore_directories[$index] = preg_quote($ignore_directory, '/');
+    }
+
+    if (!empty($ignore_directories)) {
+      $nomask = '/^(\.\.?)|CVS|' . implode('|', $ignore_directories) . '$/';
+    }
+  }
+
   // Merge in defaults.
   $options += array(
-    'nomask' => '/(\.\.?|CVS)$/',
+    'nomask' => $nomask,
     'callback' => 0,
     'recurse' => TRUE,
     'key' => 'uri',

--- a/docroot/includes/registry.inc
+++ b/docroot/includes/registry.inc
@@ -19,7 +19,6 @@
  * Does the work for registry_update().
  */
 function _registry_update() {
-
   // The registry serves as a central autoloader for all classes, including
   // the database query builders. However, the registry rebuild process
   // requires write ability to the database, which means having access to the
@@ -32,6 +31,11 @@ function _registry_update() {
   require_once DRUPAL_ROOT . '/includes/database/query.inc';
   require_once DRUPAL_ROOT . '/includes/database/select.inc';
   require_once DRUPAL_ROOT . '/includes/database/' . $driver . '/query.inc';
+
+  // During the first registry rebuild in a request, we check all the files.
+  // During subsequent rebuilds, we only add new files. It makes the rebuilding
+  // process faster during installation of modules.
+  static $check_existing_files = TRUE;
 
   // Get current list of modules and their files.
   $modules = db_query("SELECT * FROM {system} WHERE type = 'module'")->fetchAll();
@@ -55,6 +59,9 @@ function _registry_update() {
     $files["$filename"] = array('module' => '', 'weight' => 0);
   }
 
+  // Initialize an empty array for the unchanged files.
+  $unchanged_files = array();
+
   $transaction = db_transaction();
   try {
     // Allow modules to manually modify the list of files before the registry
@@ -63,10 +70,19 @@ function _registry_update() {
     // list can then be added to the list of files that the registry will parse,
     // or modify attributes of a file.
     drupal_alter('registry_files', $files, $modules);
+
     foreach (registry_get_parsed_files() as $filename => $file) {
       // Add the hash for those files we have already parsed.
       if (isset($files[$filename])) {
-        $files[$filename]['hash'] = $file['hash'];
+        if ($check_existing_files === TRUE) {
+          $files[$filename]['hash'] = $file['hash'];
+        }
+        else {
+          // Ignore that file for this request, it has been parsed previously
+          // and it is unlikely it has changed.
+          unset($files[$filename]);
+          $unchanged_files[$filename] = $file;
+        }
       }
       else {
         // Flush the registry of resources in files that are no longer on disc
@@ -79,7 +95,11 @@ function _registry_update() {
           ->execute();
       }
     }
+
     $parsed_files = _registry_parse_files($files);
+
+    // Add unchanged files to the files.
+    $files += $unchanged_files;
 
     $unchanged_resources = array();
     $lookup_cache = array();
@@ -89,18 +109,23 @@ function _registry_update() {
     foreach ($lookup_cache as $key => $file) {
       // If the file for this cached resource is carried over unchanged from
       // the last registry build, then we can safely re-cache it.
-      if ($file && in_array($file, array_keys($files)) && !in_array($file, $parsed_files)) {
+      if ($file && isset($files[$file]) && !in_array($file, $parsed_files, TRUE)) {
         $unchanged_resources[$key] = $file;
       }
     }
-    module_implements('', FALSE, TRUE);
-    _registry_check_code(REGISTRY_RESET_LOOKUP_CACHE);
   }
   catch (Exception $e) {
     $transaction->rollback();
     watchdog_exception('registry', $e);
     throw $e;
   }
+
+  module_implements('', FALSE, TRUE);
+  _registry_check_code(REGISTRY_RESET_LOOKUP_CACHE);
+
+  // During the next run in this request, don't bother re-checking existing
+  // files.
+  $check_existing_files = FALSE;
 
   // We have some unchanged resources, warm up the cache - no need to pay
   // for looking them up again.

--- a/docroot/modules/aggregator/aggregator.info
+++ b/docroot/modules/aggregator/aggregator.info
@@ -7,7 +7,7 @@ files[] = aggregator.test
 configure = admin/config/services/aggregator/settings
 stylesheets[all][] = aggregator.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/aggregator/tests/aggregator_test.info
+++ b/docroot/modules/aggregator/tests/aggregator_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/block/block.info
+++ b/docroot/modules/block/block.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = block.test
 configure = admin/structure/block
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/block/tests/block_test.info
+++ b/docroot/modules/block/tests/block_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
+++ b/docroot/modules/block/tests/themes/block_test_theme/block_test_theme.info
@@ -13,7 +13,7 @@ regions[footer] = Footer
 regions[highlighted] = Highlighted
 regions[help] = Help
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/blog/blog.info
+++ b/docroot/modules/blog/blog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = blog.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/book/book.info
+++ b/docroot/modules/book/book.info
@@ -7,7 +7,7 @@ files[] = book.test
 configure = admin/content/book/settings
 stylesheets[all][] = book.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/color/color.info
+++ b/docroot/modules/color/color.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = color.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/comment/comment.info
+++ b/docroot/modules/comment/comment.info
@@ -9,7 +9,7 @@ files[] = comment.test
 configure = admin/content/comment
 stylesheets[all][] = comment.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/contact/contact.info
+++ b/docroot/modules/contact/contact.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = contact.test
 configure = admin/structure/contact
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/contextual/contextual.info
+++ b/docroot/modules/contextual/contextual.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = contextual.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/dashboard/dashboard.info
+++ b/docroot/modules/dashboard/dashboard.info
@@ -7,7 +7,7 @@ files[] = dashboard.test
 dependencies[] = block
 configure = admin/dashboard/customize
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/dblog/dblog.info
+++ b/docroot/modules/dblog/dblog.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = dblog.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/field.info
+++ b/docroot/modules/field/field.info
@@ -11,7 +11,7 @@ dependencies[] = field_sql_storage
 required = TRUE
 stylesheets[all][] = theme/field.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
+++ b/docroot/modules/field/modules/field_sql_storage/field_sql_storage.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = field_sql_storage.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/list/list.info
+++ b/docroot/modules/field/modules/list/list.info
@@ -7,7 +7,7 @@ dependencies[] = field
 dependencies[] = options
 files[] = tests/list.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/list/tests/list_test.info
+++ b/docroot/modules/field/modules/list/tests/list_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/number/number.info
+++ b/docroot/modules/field/modules/number/number.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = number.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/number/number.test
+++ b/docroot/modules/field/modules/number/number.test
@@ -69,7 +69,7 @@ class NumberFieldTestCase extends DrupalWebTestCase {
     preg_match('|test-entity/manage/(\d+)/edit|', $this->url, $match);
     $id = $match[1];
     $this->assertRaw(t('test_entity @id has been created.', array('@id' => $id)), 'Entity was created');
-    $this->assertRaw(round($value, 2), 'Value is displayed.');
+    $this->assertRaw($value, 'Value is displayed.');
 
     // Try to create entries with more than one decimal separator; assert fail.
     $wrong_entries = array(

--- a/docroot/modules/field/modules/options/options.info
+++ b/docroot/modules/field/modules/options/options.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = options.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/modules/text/text.info
+++ b/docroot/modules/field/modules/text/text.info
@@ -7,7 +7,7 @@ dependencies[] = field
 files[] = text.test
 required = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field/tests/field_test.info
+++ b/docroot/modules/field/tests/field_test.info
@@ -6,7 +6,7 @@ files[] = field_test.entity.inc
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/field_ui/field_ui.info
+++ b/docroot/modules/field_ui/field_ui.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = field_ui.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/file/file.field.inc
+++ b/docroot/modules/file/file.field.inc
@@ -599,7 +599,7 @@ function file_field_widget_value($element, $input = FALSE, $form_state) {
     // If the display field is present make sure its unchecked value is saved.
     $field = field_widget_field($element, $form_state);
     if (empty($input['display'])) {
-      $input['display'] = $field['settings']['display_field'] ? 0 : 1;
+      $input['display'] = !empty($field['settings']['display_field']) ? 0 : 1;
     }
   }
 

--- a/docroot/modules/file/file.info
+++ b/docroot/modules/file/file.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = field
 files[] = tests/file.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/file/tests/file.test
+++ b/docroot/modules/file/tests/file.test
@@ -1875,3 +1875,60 @@ class FileFieldAnonymousSubmission extends FileFieldTestCase {
   }
 
 }
+
+/**
+ * Tests the file_scan_directory() function.
+ */
+class FileScanDirectory extends FileFieldTestCase {
+
+  /**
+   * @var string
+   */
+  protected $path;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'File ScanDirectory',
+      'description' => 'Tests the file_scan_directory() function.',
+      'group' => 'File',
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  function setUp() {
+    parent::setUp();
+
+    $this->path = 'modules/file/tests/fixtures/file_scan_ignore';
+  }
+
+  /**
+   * Tests file_scan_directory() obeys 'file_scan_ignore_directories' setting.
+   * If nomask is not passed as argument, it should use the default settings.
+   * If nomask is passed as argument, it should obey this rule.
+   */
+  public function testNoMask() {
+    $files = file_scan_directory($this->path, '/\.txt$/');
+    $this->assertEqual(3, count($files), '3 text files found when not ignoring directories.');
+
+    global $conf;
+    $conf['file_scan_ignore_directories'] = array('frontend_framework');
+
+    $files = file_scan_directory($this->path, '/\.txt$/');
+    $this->assertEqual(1, count($files), '1 text files found when ignoring directories called "frontend_framework".');
+
+    // Make that directories specified by default still work when a new nomask is provided.
+    $files = file_scan_directory($this->path, '/\.txt$/', array('nomask' => '/^c.txt/'));
+    $this->assertEqual(2, count($files), '2 text files found when an "nomask" option is passed in.');
+
+    // Ensure that the directories in file_scan_ignore_directories are escaped using preg_quote.
+    $conf['file_scan_ignore_directories'] = array('frontend.*');
+    $files = file_scan_directory($this->path, '/\.txt$/');
+    $this->assertEqual(3, count($files), '2 text files found when ignoring a directory that is not there.');
+  }
+
+}

--- a/docroot/modules/file/tests/file_module_test.info
+++ b/docroot/modules/file/tests/file_module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/filter/filter.info
+++ b/docroot/modules/filter/filter.info
@@ -7,7 +7,7 @@ files[] = filter.test
 required = TRUE
 configure = admin/config/content/formats
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/forum/forum.info
+++ b/docroot/modules/forum/forum.info
@@ -9,7 +9,7 @@ files[] = forum.test
 configure = admin/structure/forum
 stylesheets[all][] = forum.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/help/help.info
+++ b/docroot/modules/help/help.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = help.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/image/image.admin.inc
+++ b/docroot/modules/image/image.admin.inc
@@ -81,6 +81,12 @@ function image_style_form($form, &$form_state, $style) {
     ),
   );
 
+  // Note about SVG images and effects.
+  $form['effects_svg'] = array(
+      '#type' => 'item',
+      '#title' => t('Note regarding SVG!'),
+      '#description' => t('Effects don\'t apply to SVG images, except for the Scale effect.'),
+  );
   // Build the list of existing image effects for this image style.
   $form['effects'] = array(
     '#theme' => 'image_style_effects',

--- a/docroot/modules/image/image.admin.inc
+++ b/docroot/modules/image/image.admin.inc
@@ -81,12 +81,6 @@ function image_style_form($form, &$form_state, $style) {
     ),
   );
 
-  // Note about SVG images and effects.
-  $form['effects_svg'] = array(
-      '#type' => 'item',
-      '#title' => t('Note regarding SVG!'),
-      '#description' => t('Effects don\'t apply to SVG images, except for the Scale effect.'),
-  );
   // Build the list of existing image effects for this image style.
   $form['effects'] = array(
     '#theme' => 'image_style_effects',

--- a/docroot/modules/image/image.field.inc
+++ b/docroot/modules/image/image.field.inc
@@ -18,7 +18,7 @@ function image_field_info() {
         'default_image' => 0,
       ),
       'instance_settings' => array(
-        'file_extensions' => 'png gif jpg jpeg svg',
+        'file_extensions' => 'png gif jpg jpeg',
         'file_directory' => '',
         'max_filesize' => '',
         'alt_field' => 0,
@@ -339,7 +339,7 @@ function image_field_widget_form(&$form, &$form_state, $field, $instance, $langc
     }
 
     // If not using custom extension validation, ensure this is an image.
-    $supported_extensions = array('png', 'gif', 'jpg', 'jpeg', 'svg');
+    $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
     $extensions = isset($elements[$delta]['#upload_validators']['file_validate_extensions'][0]) ? $elements[$delta]['#upload_validators']['file_validate_extensions'][0] : implode(' ', $supported_extensions);
     $extensions = array_intersect(explode(' ', $extensions), $supported_extensions);
     $elements[$delta]['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);

--- a/docroot/modules/image/image.field.inc
+++ b/docroot/modules/image/image.field.inc
@@ -18,7 +18,7 @@ function image_field_info() {
         'default_image' => 0,
       ),
       'instance_settings' => array(
-        'file_extensions' => 'png gif jpg jpeg',
+        'file_extensions' => 'png gif jpg jpeg svg',
         'file_directory' => '',
         'max_filesize' => '',
         'alt_field' => 0,
@@ -339,7 +339,7 @@ function image_field_widget_form(&$form, &$form_state, $field, $instance, $langc
     }
 
     // If not using custom extension validation, ensure this is an image.
-    $supported_extensions = array('png', 'gif', 'jpg', 'jpeg');
+    $supported_extensions = array('png', 'gif', 'jpg', 'jpeg', 'svg');
     $extensions = isset($elements[$delta]['#upload_validators']['file_validate_extensions'][0]) ? $elements[$delta]['#upload_validators']['file_validate_extensions'][0] : implode(' ', $supported_extensions);
     $extensions = array_intersect(explode(' ', $extensions), $supported_extensions);
     $elements[$delta]['#upload_validators']['file_validate_extensions'][0] = implode(' ', $extensions);

--- a/docroot/modules/image/image.info
+++ b/docroot/modules/image/image.info
@@ -7,7 +7,7 @@ dependencies[] = file
 files[] = image.test
 configure = admin/config/media/image-styles
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/image/image.module
+++ b/docroot/modules/image/image.module
@@ -925,13 +925,8 @@ function image_style_create_derivative($style, $source, $destination) {
     return FALSE;
   }
 
-  if ($image->info['extension'] == 'svg') {
-    // Don't process SVG images.
-  }
-  else {
-    foreach ($style['effects'] as $effect) {
-      image_effect_apply($image, $effect);
-    }
+  foreach ($style['effects'] as $effect) {
+    image_effect_apply($image, $effect);
   }
 
   if (!image_save($image, $destination)) {

--- a/docroot/modules/image/image.module
+++ b/docroot/modules/image/image.module
@@ -925,8 +925,13 @@ function image_style_create_derivative($style, $source, $destination) {
     return FALSE;
   }
 
-  foreach ($style['effects'] as $effect) {
-    image_effect_apply($image, $effect);
+  if ($image->info['extension'] == 'svg') {
+    // Don't process SVG images.
+  }
+  else {
+    foreach ($style['effects'] as $effect) {
+      image_effect_apply($image, $effect);
+    }
   }
 
   if (!image_save($image, $destination)) {

--- a/docroot/modules/image/tests/image_module_test.info
+++ b/docroot/modules/image/tests/image_module_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = image_module_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/locale/locale.info
+++ b/docroot/modules/locale/locale.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = locale.test
 configure = admin/config/regional/language
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/locale/tests/locale_test.info
+++ b/docroot/modules/locale/tests/locale_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/menu/menu.info
+++ b/docroot/modules/menu/menu.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = menu.test
 configure = admin/structure/menu
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/node/node.info
+++ b/docroot/modules/node/node.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/structure/types
 stylesheets[all][] = node.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/node/tests/node_access_test.info
+++ b/docroot/modules/node/tests/node_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/node/tests/node_test.info
+++ b/docroot/modules/node/tests/node_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/node/tests/node_test_exception.info
+++ b/docroot/modules/node/tests/node_test_exception.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/openid/openid.info
+++ b/docroot/modules/openid/openid.info
@@ -5,7 +5,7 @@ package = Core
 core = 7.x
 files[] = openid.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/openid/tests/openid_test.info
+++ b/docroot/modules/openid/tests/openid_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = openid
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/overlay/overlay.info
+++ b/docroot/modules/overlay/overlay.info
@@ -4,7 +4,7 @@ package = Core
 version = VERSION
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/path/path.info
+++ b/docroot/modules/path/path.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = path.test
 configure = admin/config/search/path
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/php/php.info
+++ b/docroot/modules/php/php.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = php.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/poll/poll.info
+++ b/docroot/modules/poll/poll.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = poll.test
 stylesheets[all][] = poll.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/profile/profile.info
+++ b/docroot/modules/profile/profile.info
@@ -11,7 +11,7 @@ configure = admin/config/people/profile
 ; See user_system_info_alter().
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/rdf/rdf.info
+++ b/docroot/modules/rdf/rdf.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 files[] = rdf.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/rdf/tests/rdf_test.info
+++ b/docroot/modules/rdf/tests/rdf_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = blog
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/search/search.info
+++ b/docroot/modules/search/search.info
@@ -8,7 +8,7 @@ files[] = search.test
 configure = admin/config/search/settings
 stylesheets[all][] = search.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/search/tests/search_embedded_form.info
+++ b/docroot/modules/search/tests/search_embedded_form.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/search/tests/search_extra_type.info
+++ b/docroot/modules/search/tests/search_extra_type.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/search/tests/search_node_tags.info
+++ b/docroot/modules/search/tests/search_node_tags.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/shortcut/shortcut.info
+++ b/docroot/modules/shortcut/shortcut.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = shortcut.test
 configure = admin/config/user-interface/shortcut
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/drupal_web_test_case.php
+++ b/docroot/modules/simpletest/drupal_web_test_case.php
@@ -3012,7 +3012,7 @@ class DrupalWebTestCase extends DrupalTestCase {
     if (!$message) {
       $message = t('Raw "@raw" found', array('@raw' => $raw));
     }
-    return $this->assert(strpos($this->drupalGetContent(), $raw) !== FALSE, $message, $group);
+    return $this->assert(strpos($this->drupalGetContent(), (string) $raw) !== FALSE, $message, $group);
   }
 
   /**
@@ -3032,7 +3032,7 @@ class DrupalWebTestCase extends DrupalTestCase {
     if (!$message) {
       $message = t('Raw "@raw" not found', array('@raw' => $raw));
     }
-    return $this->assert(strpos($this->drupalGetContent(), $raw) === FALSE, $message, $group);
+    return $this->assert(strpos($this->drupalGetContent(), (string) $raw) === FALSE, $message, $group);
   }
 
   /**

--- a/docroot/modules/simpletest/simpletest.info
+++ b/docroot/modules/simpletest/simpletest.info
@@ -57,7 +57,7 @@ files[] = tests/upgrade/update.trigger.test
 files[] = tests/upgrade/update.field.test
 files[] = tests/upgrade/update.user.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/actions_loop_test.info
+++ b/docroot/modules/simpletest/tests/actions_loop_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/ajax_forms_test.info
+++ b/docroot/modules/simpletest/tests/ajax_forms_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/ajax_test.info
+++ b/docroot/modules/simpletest/tests/ajax_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/batch_test.info
+++ b/docroot/modules/simpletest/tests/batch_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/boot_test_1.info
+++ b/docroot/modules/simpletest/tests/boot_test_1.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/boot_test_2.info
+++ b/docroot/modules/simpletest/tests/boot_test_2.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/bootstrap.test
+++ b/docroot/modules/simpletest/tests/bootstrap.test
@@ -729,16 +729,12 @@ class BootstrapMiscTestCase extends DrupalUnitTestCase {
    * Tests that the drupal_check_memory_limit() function works as expected.
    */
   function testCheckMemoryLimit() {
-    $memory_limit = ini_get('memory_limit');
     // Test that a very reasonable amount of memory is available.
     $this->assertTrue(drupal_check_memory_limit('30MB'), '30MB of memory tested available.');
 
-    // Get the available memory and multiply it by two to make it unreasonably
-    // high.
-    $twice_avail_memory = ($memory_limit * 2) . 'MB';
-
+    // Test an unlimited memory limit.
     // The function should always return true if the memory limit is set to -1.
-    $this->assertTrue(drupal_check_memory_limit($twice_avail_memory, -1), 'drupal_check_memory_limit() returns TRUE when a limit of -1 (none) is supplied');
+    $this->assertTrue(drupal_check_memory_limit('9999999999YB', -1), 'drupal_check_memory_limit() returns TRUE when a limit of -1 (none) is supplied');
 
     // Test that even though we have 30MB of memory available - the function
     // returns FALSE when given an upper limit for how much memory can be used.

--- a/docroot/modules/simpletest/tests/common_test.info
+++ b/docroot/modules/simpletest/tests/common_test.info
@@ -7,7 +7,7 @@ stylesheets[all][] = common_test.css
 stylesheets[print][] = common_test.print.css
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/common_test_cron_helper.info
+++ b/docroot/modules/simpletest/tests/common_test_cron_helper.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/database_test.info
+++ b/docroot/modules/simpletest/tests/database_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
+++ b/docroot/modules/simpletest/tests/drupal_autoload_test/drupal_autoload_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/modules/simpletest/tests/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/entity_cache_test.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test.info
@@ -6,7 +6,7 @@ core = 7.x
 dependencies[] = entity_cache_test_dependency
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
+++ b/docroot/modules/simpletest/tests/entity_cache_test_dependency.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/entity_crud_hook_test.info
+++ b/docroot/modules/simpletest/tests/entity_crud_hook_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/entity_query_access_test.info
+++ b/docroot/modules/simpletest/tests/entity_query_access_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/error_test.info
+++ b/docroot/modules/simpletest/tests/error_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/file_test.info
+++ b/docroot/modules/simpletest/tests/file_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = file_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/filter_test.info
+++ b/docroot/modules/simpletest/tests/filter_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/form_test.info
+++ b/docroot/modules/simpletest/tests/form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/image_test.info
+++ b/docroot/modules/simpletest/tests/image_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/menu_test.info
+++ b/docroot/modules/simpletest/tests/menu_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/module_test.info
+++ b/docroot/modules/simpletest/tests/module_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/path_test.info
+++ b/docroot/modules/simpletest/tests/path_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
+++ b/docroot/modules/simpletest/tests/psr_0_test/psr_0_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
+++ b/docroot/modules/simpletest/tests/psr_4_test/psr_4_test.info
@@ -5,7 +5,7 @@ core = 7.x
 hidden = TRUE
 package = Testing
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/requirements1_test.info
+++ b/docroot/modules/simpletest/tests/requirements1_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/requirements2_test.info
+++ b/docroot/modules/simpletest/tests/requirements2_test.info
@@ -7,7 +7,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/session_test.info
+++ b/docroot/modules/simpletest/tests/session_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = _missing_dependency
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_dependencies_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = system_incompatible_core_version_test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_core_version_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 5.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_dependencies_test.info
@@ -7,7 +7,7 @@ hidden = TRUE
 ; system_incompatible_module_version_test declares version 1.0
 dependencies[] = system_incompatible_module_version_test (>2.0)
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
+++ b/docroot/modules/simpletest/tests/system_incompatible_module_version_test.info
@@ -5,7 +5,7 @@ version = 1.0
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_project_namespace_test.info
+++ b/docroot/modules/simpletest/tests/system_project_namespace_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = drupal:filter
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/system_test.info
+++ b/docroot/modules/simpletest/tests/system_test.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = system_test.module
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/taxonomy_test.info
+++ b/docroot/modules/simpletest/tests/taxonomy_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/theme_test.info
+++ b/docroot/modules/simpletest/tests/theme_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_basetheme/test_basetheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 settings[basetheme_only] = base theme value
 settings[subtheme_override] = base theme value
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
+++ b/docroot/modules/simpletest/tests/themes/test_subtheme/test_subtheme.info
@@ -6,7 +6,7 @@ hidden = TRUE
 
 settings[subtheme_override] = subtheme value
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme/test_theme.info
@@ -17,7 +17,7 @@ stylesheets[all][] = system.base.css
 
 settings[theme_test_setting] = default value
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
+++ b/docroot/modules/simpletest/tests/themes/test_theme_nyan_cat/test_theme_nyan_cat.info
@@ -4,7 +4,7 @@ core = 7.x
 hidden = TRUE
 engine = nyan_cat
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/update_script_test.info
+++ b/docroot/modules/simpletest/tests/update_script_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/update_test_1.info
+++ b/docroot/modules/simpletest/tests/update_test_1.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/update_test_2.info
+++ b/docroot/modules/simpletest/tests/update_test_2.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/update_test_3.info
+++ b/docroot/modules/simpletest/tests/update_test_3.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/url_alter_test.info
+++ b/docroot/modules/simpletest/tests/url_alter_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/simpletest/tests/xmlrpc_test.info
+++ b/docroot/modules/simpletest/tests/xmlrpc_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/statistics/statistics.info
+++ b/docroot/modules/statistics/statistics.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = statistics.test
 configure = admin/config/system/statistics
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/syslog/syslog.info
+++ b/docroot/modules/syslog/syslog.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = syslog.test
 configure = admin/config/development/logging
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/system/image.gd.inc
+++ b/docroot/modules/system/image.gd.inc
@@ -28,6 +28,24 @@ function image_gd_settings() {
       '#default_value' => variable_get('image_jpeg_quality', 75),
       '#field_suffix' => t('%'),
     );
+    $form['image_svg_width'] = array(
+        '#type' => 'textfield',
+        '#title' => t('SVG width'),
+        '#description' => t('Define the default width of a SVG image. Note that the changing this only affects new uploads!'),
+        '#size' => 10,
+        '#maxlength' => 4,
+        '#default_value' => variable_get('image_svg_width', 480),
+        '#field_suffix' => t('px'),
+    );
+    $form['image_svg_height'] = array(
+        '#type' => 'textfield',
+        '#title' => t('SVG height'),
+        '#description' => t('Define the default height of a SVG image. Note that the changing this only affects new uploads!'),
+        '#size' => 10,
+        '#maxlength' => 4,
+        '#default_value' => variable_get('image_svg_height', 320),
+        '#field_suffix' => t('px'),
+    );
     $form['#element_validate'] = array('image_gd_settings_validate');
 
     return $form;
@@ -270,6 +288,10 @@ function image_gd_load(stdClass $image) {
     }
     return (bool) $image->resource;
   }
+  else if ($extension == 'svg') {
+    // Pass through SVG images.
+    return TRUE;
+  }
   return FALSE;
 }
 
@@ -301,11 +323,15 @@ function image_gd_save(stdClass $image, $destination) {
 
   $extension = str_replace('jpg', 'jpeg', $image->info['extension']);
   $function = 'image' . $extension;
-  if (!function_exists($function)) {
+  if (!function_exists($function) && $extension != 'svg') {
     return FALSE;
   }
   if ($extension == 'jpeg') {
     $success = $function($image->resource, $destination, variable_get('image_jpeg_quality', 75));
+  }
+  else if ($extension == 'svg') {
+    // Pass through SVG images.
+    $success = (bool) file_unmanaged_copy($image->source, $destination, FILE_EXISTS_REPLACE);
   }
   else {
     // Always save PNG images with full transparency.
@@ -406,6 +432,17 @@ function image_gd_get_info(stdClass $image) {
       'height'    => $data[1],
       'extension' => $extension,
       'mime_type' => $data['mime'],
+    );
+  }
+  else if ($mimetype = file_get_mimetype($image->source) == 'image/svg+xml') {
+    // Pass throught SVG images.
+    $width = variable_get('image_svg_width', 480);
+    $height = variable_get('image_svg_height', 320);
+    $details = array(
+        'width'     => $width,
+        'height'    => $height,
+        'extension' => 'svg',
+        'mime_type' => $mimetype,
     );
   }
 

--- a/docroot/modules/system/image.gd.inc
+++ b/docroot/modules/system/image.gd.inc
@@ -28,24 +28,6 @@ function image_gd_settings() {
       '#default_value' => variable_get('image_jpeg_quality', 75),
       '#field_suffix' => t('%'),
     );
-    $form['image_svg_width'] = array(
-        '#type' => 'textfield',
-        '#title' => t('SVG width'),
-        '#description' => t('Define the default width of a SVG image. Note that the changing this only affects new uploads!'),
-        '#size' => 10,
-        '#maxlength' => 4,
-        '#default_value' => variable_get('image_svg_width', 480),
-        '#field_suffix' => t('px'),
-    );
-    $form['image_svg_height'] = array(
-        '#type' => 'textfield',
-        '#title' => t('SVG height'),
-        '#description' => t('Define the default height of a SVG image. Note that the changing this only affects new uploads!'),
-        '#size' => 10,
-        '#maxlength' => 4,
-        '#default_value' => variable_get('image_svg_height', 320),
-        '#field_suffix' => t('px'),
-    );
     $form['#element_validate'] = array('image_gd_settings_validate');
 
     return $form;
@@ -288,10 +270,6 @@ function image_gd_load(stdClass $image) {
     }
     return (bool) $image->resource;
   }
-  else if ($extension == 'svg') {
-    // Pass through SVG images.
-    return TRUE;
-  }
   return FALSE;
 }
 
@@ -323,15 +301,11 @@ function image_gd_save(stdClass $image, $destination) {
 
   $extension = str_replace('jpg', 'jpeg', $image->info['extension']);
   $function = 'image' . $extension;
-  if (!function_exists($function) && $extension != 'svg') {
+  if (!function_exists($function)) {
     return FALSE;
   }
   if ($extension == 'jpeg') {
     $success = $function($image->resource, $destination, variable_get('image_jpeg_quality', 75));
-  }
-  else if ($extension == 'svg') {
-    // Pass through SVG images.
-    $success = (bool) file_unmanaged_copy($image->source, $destination, FILE_EXISTS_REPLACE);
   }
   else {
     // Always save PNG images with full transparency.
@@ -432,17 +406,6 @@ function image_gd_get_info(stdClass $image) {
       'height'    => $data[1],
       'extension' => $extension,
       'mime_type' => $data['mime'],
-    );
-  }
-  else if ($mimetype = file_get_mimetype($image->source) == 'image/svg+xml') {
-    // Pass throught SVG images.
-    $width = variable_get('image_svg_width', 480);
-    $height = variable_get('image_svg_height', 320);
-    $details = array(
-        'width'     => $width,
-        'height'    => $height,
-        'extension' => 'svg',
-        'mime_type' => $mimetype,
     );
   }
 

--- a/docroot/modules/system/system.info
+++ b/docroot/modules/system/system.info
@@ -12,7 +12,7 @@ files[] = system.test
 required = TRUE
 configure = admin/config/system
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/system/system.install
+++ b/docroot/modules/system/system.install
@@ -2870,7 +2870,7 @@ function system_update_7061(&$sandbox) {
     if (!db_table_exists('system_update_7061')) {
       $table = array(
         'description' => t('Stores temporary data for system_update_7061.'),
-        'fields' => array('vid' => array('type' => 'int')),
+        'fields' => array('vid' => array('type' => 'int', 'not null' => TRUE)),
         'primary key' => array('vid'),
       );
       db_create_table('system_update_7061', $table);

--- a/docroot/modules/system/tests/cron_queue_test.info
+++ b/docroot/modules/system/tests/cron_queue_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/system/tests/system_cron_test.info
+++ b/docroot/modules/system/tests/system_cron_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/taxonomy/taxonomy.info
+++ b/docroot/modules/taxonomy/taxonomy.info
@@ -8,7 +8,7 @@ files[] = taxonomy.module
 files[] = taxonomy.test
 configure = admin/structure/taxonomy
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/taxonomy/taxonomy.module
+++ b/docroot/modules/taxonomy/taxonomy.module
@@ -1442,8 +1442,6 @@ function taxonomy_implode_tags($tags, $vid = NULL) {
  *   - parent: a term ID of a term whose children are allowed. This should be
  *     '0' if all terms in a vocabulary are allowed. The allowed values do not
  *     include the parent term.
- * - allow_term_autocreation: a boolean indicating whether or not unknown
- *   values will be converted to new terms in the vocabulary
  *
  */
 function taxonomy_field_info() {
@@ -1460,7 +1458,6 @@ function taxonomy_field_info() {
             'parent' => '0',
           ),
         ),
-        'allow_term_autocreation' => TRUE,
       ),
     ),
   );
@@ -1779,7 +1776,7 @@ function taxonomy_autocomplete_validate($element, &$form_state) {
       if ($possibilities = taxonomy_term_load_multiple(array(), array('name' => trim($typed_term), 'vid' => array_keys($vocabularies)))) {
         $term = array_pop($possibilities);
       }
-      else if (!isset($field['settings']['allow_term_autocreation']) || $field['settings']['allow_term_autocreation']) {
+      else {
         $vocabulary = reset($vocabularies);
         $term = array(
           'tid' => 'autocreate',
@@ -1788,14 +1785,7 @@ function taxonomy_autocomplete_validate($element, &$form_state) {
           'vocabulary_machine_name' => $vocabulary->machine_name,
         );
       }
-      else {
-        $term = NULL;
-        form_error($element, t('%name: illegal value: %value.', array('%name' => t($element['#title']), '%value' => $typed_term)));
-      }
-
-      if (isset($term)) {
-        $value[] = (array)$term;
-      }
+      $value[] = (array)$term;
     }
   }
 
@@ -1837,13 +1827,6 @@ function taxonomy_field_settings_form($field, $instance, $has_data) {
       '#value' => $tree['parent'],
     );
   }
-
-  $form['allow_term_autocreation'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow autocreation of new terms'),
-    '#default_value' => (!isset($field['settings']['allow_term_autocreation']) || $field['settings']['allow_term_autocreation']) ? TRUE : FALSE,
-    '#description' => t('When enabled, new terms are automatically created for unknown values.'),
-  );
 
   return $form;
 }

--- a/docroot/modules/taxonomy/taxonomy.module
+++ b/docroot/modules/taxonomy/taxonomy.module
@@ -1442,6 +1442,8 @@ function taxonomy_implode_tags($tags, $vid = NULL) {
  *   - parent: a term ID of a term whose children are allowed. This should be
  *     '0' if all terms in a vocabulary are allowed. The allowed values do not
  *     include the parent term.
+ * - allow_term_autocreation: a boolean indicating whether or not unknown
+ *   values will be converted to new terms in the vocabulary
  *
  */
 function taxonomy_field_info() {
@@ -1458,6 +1460,7 @@ function taxonomy_field_info() {
             'parent' => '0',
           ),
         ),
+        'allow_term_autocreation' => TRUE,
       ),
     ),
   );
@@ -1776,7 +1779,7 @@ function taxonomy_autocomplete_validate($element, &$form_state) {
       if ($possibilities = taxonomy_term_load_multiple(array(), array('name' => trim($typed_term), 'vid' => array_keys($vocabularies)))) {
         $term = array_pop($possibilities);
       }
-      else {
+      else if (!isset($field['settings']['allow_term_autocreation']) || $field['settings']['allow_term_autocreation']) {
         $vocabulary = reset($vocabularies);
         $term = array(
           'tid' => 'autocreate',
@@ -1785,7 +1788,14 @@ function taxonomy_autocomplete_validate($element, &$form_state) {
           'vocabulary_machine_name' => $vocabulary->machine_name,
         );
       }
-      $value[] = (array)$term;
+      else {
+        $term = NULL;
+        form_error($element, t('%name: illegal value: %value.', array('%name' => t($element['#title']), '%value' => $typed_term)));
+      }
+
+      if (isset($term)) {
+        $value[] = (array)$term;
+      }
     }
   }
 
@@ -1827,6 +1837,13 @@ function taxonomy_field_settings_form($field, $instance, $has_data) {
       '#value' => $tree['parent'],
     );
   }
+
+  $form['allow_term_autocreation'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Allow autocreation of new terms'),
+    '#default_value' => (!isset($field['settings']['allow_term_autocreation']) || $field['settings']['allow_term_autocreation']) ? TRUE : FALSE,
+    '#description' => t('When enabled, new terms are automatically created for unknown values.'),
+  );
 
   return $form;
 }

--- a/docroot/modules/toolbar/toolbar.info
+++ b/docroot/modules/toolbar/toolbar.info
@@ -4,7 +4,7 @@ core = 7.x
 package = Core
 version = VERSION
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/tracker/tracker.info
+++ b/docroot/modules/tracker/tracker.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = tracker.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/translation/tests/translation_test.info
+++ b/docroot/modules/translation/tests/translation_test.info
@@ -5,7 +5,7 @@ package = Testing
 version = VERSION
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/translation/translation.info
+++ b/docroot/modules/translation/translation.info
@@ -6,7 +6,7 @@ version = VERSION
 core = 7.x
 files[] = translation.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/trigger/tests/trigger_test.info
+++ b/docroot/modules/trigger/tests/trigger_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/trigger/trigger.info
+++ b/docroot/modules/trigger/trigger.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = trigger.test
 configure = admin/structure/trigger
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/aaa_update_test.info
+++ b/docroot/modules/update/tests/aaa_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/bbb_update_test.info
+++ b/docroot/modules/update/tests/bbb_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/ccc_update_test.info
+++ b/docroot/modules/update/tests/ccc_update_test.info
@@ -4,7 +4,7 @@ package = Testing
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
+++ b/docroot/modules/update/tests/themes/update_test_admintheme/update_test_admintheme.info
@@ -3,7 +3,7 @@ description = Test theme which is used as admin theme.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
+++ b/docroot/modules/update/tests/themes/update_test_basetheme/update_test_basetheme.info
@@ -3,7 +3,7 @@ description = Test theme which acts as a base theme for other test subthemes.
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
+++ b/docroot/modules/update/tests/themes/update_test_subtheme/update_test_subtheme.info
@@ -4,7 +4,7 @@ core = 7.x
 base theme = update_test_basetheme
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/tests/update_test.info
+++ b/docroot/modules/update/tests/update_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/update/update.info
+++ b/docroot/modules/update/update.info
@@ -6,7 +6,7 @@ core = 7.x
 files[] = update.test
 configure = admin/reports/updates/settings
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/user/tests/user_form_test.info
+++ b/docroot/modules/user/tests/user_form_test.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/modules/user/user.info
+++ b/docroot/modules/user/user.info
@@ -9,7 +9,7 @@ required = TRUE
 configure = admin/config/people
 stylesheets[all][] = user.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/bulk_export/bulk_export.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/bulk_export/bulk_export.info
@@ -3,11 +3,9 @@ description = Performs bulk exporting of data objects known about by Chaos tools
 core = 7.x
 dependencies[] = ctools
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/css/dropbutton.css
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/css/dropbutton.css
@@ -19,7 +19,6 @@
   height: auto;
   position: absolute;
   right: 0;
-  text-indent: -9999px; /* LTR */
   top: 0;
   width: 17px;
 }
@@ -50,6 +49,7 @@
   right: 6px;
   position: absolute;
   top: 0.75em;
+  white-space: nowrap;
 }
 
 .ctools-dropbutton-processed.open .ctools-twisty {

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools.info
@@ -19,9 +19,8 @@ files[] = tests/object_cache.test
 files[] = tests/object_cache_unit.test
 files[] = tests/page_tokens.test
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools.module
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools.module
@@ -22,6 +22,9 @@ define('CTOOLS_API_VERSION', '2.0.9');
  * simply include a dependency line in that module's info file, e.g.:
  *   ; Requires CTools v7.x-1.4 or newer.
  *   dependencies[] = ctools (>=1.4)
+ *
+ * @deprecated in CTools 1.15 and will be removed before CTools 2.0.0.
+ *   Use the version provided by the drupal.org packaging system.
  */
 define('CTOOLS_MODULE_VERSION', '7.x-1.13');
 

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools_access_ruleset/ctools_access_ruleset.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools_access_ruleset/ctools_access_ruleset.info
@@ -2,12 +2,10 @@ name = Custom rulesets
 description = Create custom, exportable, reusable access rulesets for applications like Panels.
 core = 7.x
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools_ajax_sample/ctools_ajax_sample.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools_ajax_sample/ctools_ajax_sample.info
@@ -1,13 +1,11 @@
 name = Chaos Tools (CTools) AJAX Example
 description = Shows how to use the power of Chaos AJAX.
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools_custom_content/ctools_custom_content.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools_custom_content/ctools_custom_content.info
@@ -2,12 +2,10 @@ name = Custom content panes
 description = Create custom, exportable, reusable content panes for applications like Panels.
 core = 7.x
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools_plugin_example/ctools_plugin_example.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools_plugin_example/ctools_plugin_example.info
@@ -1,16 +1,14 @@
 name = Chaos Tools (CTools) Plugin Example
 description = Shows how an external module can provide ctools plugins (for Panels, etc.).
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 dependencies[] = panels
 dependencies[] = page_manager
 dependencies[] = advanced_help
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/ctools_plugin_example/ctools_plugin_example.pages_default.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/ctools_plugin_example/ctools_plugin_example.pages_default.inc
@@ -95,6 +95,7 @@ function ctools_plugin_example_default_page_manager_pages() {
     'access' => array(
       'logic' => 'and',
     ),
+    'pipeline' => 'standard',
   );
   $display = new panels_display();
   $display->layout = 'threecol_33_34_33_stacked';
@@ -154,7 +155,7 @@ function ctools_plugin_example_default_page_manager_pages() {
   $pane->configuration = array(
     'title' => 'Long Arg Visibility Block',
     'body' => 'This block will be here when the argument is longer than configured arg length. It uses the \'arg_length\' access plugin to test against the length of the argument used for Simplecontext.',
-    'format' => '1',
+    'format' => 'filtered_html',
     'substitute' => 1,
   );
   $pane->cache = array();
@@ -185,7 +186,7 @@ function ctools_plugin_example_default_page_manager_pages() {
   $pane->configuration = array(
     'title' => 'Short Arg Visibility',
     'body' => 'This block appears when the simplecontext argument is <i>less than</i> the configured length.',
-    'format' => '1',
+    'format' => 'filtered_html',
     'substitute' => 1,
   );
   $pane->cache = array();
@@ -297,7 +298,7 @@ function ctools_plugin_example_default_page_manager_pages() {
     item1 is %sc:item1
     item2 is %sc:item2
     description is %sc:description',
-    'format' => '1',
+    'format' => 'filtered_html',
     'substitute' => 1,
   );
   $pane->cache = array();
@@ -363,7 +364,7 @@ function ctools_plugin_example_default_page_manager_pages() {
     'body' => 'The CTools Plugin Example module (and this panel page) are just here to demonstrate how to build CTools plugins.
 
             ',
-    'format' => '2',
+    'format' => 'full_html',
     'substitute' => 1,
   );
   $pane->cache = array();
@@ -408,6 +409,7 @@ function ctools_plugin_example_default_page_manager_pages() {
     'css' => '',
     'contexts' => array(),
     'relationships' => array(),
+    'pipeline' => 'standard',
   );
   $display = new panels_display();
   $display->layout = 'onecol';
@@ -428,7 +430,7 @@ function ctools_plugin_example_default_page_manager_pages() {
   $pane->configuration = array(
     'title' => 'Use this page with an argument',
     'body' => 'This demo page works if you use an argument, like <a href="ctools_plugin_example/xxxxx">ctools_plugin_example/xxxxx</a>.',
-    'format' => '1',
+    'format' => 'filtered_html',
     'substitute' => NULL,
   );
   $pane->cache = array();

--- a/docroot/profiles/favrskov/modules/contrib/ctools/drush/ctools.drush.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/drush/ctools.drush.inc
@@ -452,6 +452,7 @@ function ctools_drush_export_info() {
  * all arg handling etc in one place.
  */
 function ctools_drush_export_op_command() {
+  $args = func_get_args();
   // Get all info for the current drush command.
   $command = drush_get_command();
   $op = '';
@@ -495,7 +496,6 @@ function ctools_drush_export_op_command() {
     }
   }
   else {
-    $args = func_get_args();
     // Table name should always be first arg...
     $table_name = array_shift($args);
     // Any additional args are assumed to be exportable names.

--- a/docroot/profiles/favrskov/modules/contrib/ctools/includes/dropbutton.theme.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/includes/dropbutton.theme.inc
@@ -104,10 +104,10 @@ function theme_links__ctools_dropbutton($vars) {
 
       $output .= '<div class="ctools-link">';
       if ($vars['image']) {
-        $output .= '<a href="#" class="ctools-twisty ctools-image">' . $vars['title'] . '</a>';
+        $output .= '<a href="#" class="ctools-twisty ctools-image"><span class="element-invisible">' . $vars['title'] . '</span></a>';
       }
       else {
-        $output .= '<a href="#" class="ctools-twisty ctools-text">' . $vars['title'] . '</a>';
+        $output .= '<a href="#" class="ctools-twisty ctools-text"><span class="element-invisible">' . $vars['title'] . '</span></a>';
       }
       // ctools-link.
       $output .= '</div>';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/includes/export-ui.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/includes/export-ui.inc
@@ -333,7 +333,7 @@ function ctools_export_ui_process(&$plugin, $info) {
 
   $plugin['strings']['confirmation']['delete'] += array(
     'question' => t('Are you sure you want to delete %title?'),
-    'information' => t('This action will permanently remove this item from your database..'),
+    'information' => t('This action will permanently remove this item from your database.'),
     'success' => t('The item has been deleted.'),
   );
 

--- a/docroot/profiles/favrskov/modules/contrib/ctools/includes/wizard.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/includes/wizard.inc
@@ -503,7 +503,7 @@ function ctools_wizard_defaults(&$form_info) {
   $form_info = $form_info + $defaults;
   // Set form callbacks if they aren't defined.
   foreach ($form_info['forms'] as $step => $params) {
-    if (!$params['form id']) {
+    if (empty($params['form id'])) {
       $form_callback = $hook . '_' . $step . '_form';
       $form_info['forms'][$step]['form id'] = $form_callback;
     }

--- a/docroot/profiles/favrskov/modules/contrib/ctools/js/modal.js
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/js/modal.js
@@ -378,7 +378,7 @@
       }
     }
 
-    if (!speed) {
+    if (!speed && 0 !== speed) {
       speed = 'fast';
     }
 
@@ -555,7 +555,7 @@
     // Create our content div, get the dimensions, and hide it
     var modalContent = $('#modalContent').css('top','-1000px');
     var $modalHeader = modalContent.find('.modal-header');
-    var mdcTop = wt + ( winHeight / 2 ) - (  modalContent.outerHeight() / 2);
+    var mdcTop = wt + Math.max((winHeight / 2) - (modalContent.outerHeight() / 2), 0);
     var mdcLeft = ( winWidth / 2 ) - ( modalContent.outerWidth() / 2);
     $('#modalBackdrop').css(css).css('top', 0).css('height', docHeight + 'px').css('width', docWidth + 'px').show();
     modalContent.css({top: mdcTop + 'px', left: mdcLeft + 'px'}).hide()[animation](speed);
@@ -588,35 +588,43 @@
       $('body').unbind( 'keypress', modalEventHandler );
       $('body').unbind( 'keydown', modalTabTrapHandler );
       $('.close', $modalHeader).unbind('click', modalContentClose);
-      $('body').unbind('keypress', modalEventEscapeCloseHandler);
+      $(document).unbind('keydown', modalEventEscapeCloseHandler);
       $(document).trigger('CToolsDetachBehaviors', $('#modalContent'));
 
-      // Set our animation parameters and use them
-      if ( animation == 'fadeIn' ) animation = 'fadeOut';
-      if ( animation == 'slideDown' ) animation = 'slideUp';
-      if ( animation == 'show' ) animation = 'hide';
+      // Closing animation.
+      switch (animation) {
+        case 'fadeIn':
+          modalContent.fadeOut(speed, modalContentRemove);
+          break;
 
-      // Close the content
-      modalContent.hide()[animation](speed);
+        case 'slideDown':
+          modalContent.slideUp(speed, modalContentRemove);
+          break;
 
-      // Remove the content
+        case 'show':
+          modalContent.hide(speed, modalContentRemove);
+          break;
+      }
+    }
+
+    // Remove the content.
+    modalContentRemove = function () {
       $('#modalContent').remove();
       $('#modalBackdrop').remove();
 
-      // Restore focus to where it was before opening the dialog
+      // Restore focus to where it was before opening the dialog.
       $(oldFocus).focus();
     };
 
     // Move and resize the modalBackdrop and modalContent on window resize.
-    modalContentResize = function(){
-
+    modalContentResize = function () {
       // Reset the backdrop height/width to get accurate document size.
       $('#modalBackdrop').css('height', '').css('width', '');
 
       // Position code lifted from:
       // http://www.quirksmode.org/viewport/compatibility.html
       if (self.pageYOffset) { // all except Explorer
-      var wt = self.pageYOffset;
+        var wt = self.pageYOffset;
       } else if (document.documentElement && document.documentElement.scrollTop) { // Explorer 6 Strict
         var wt = document.documentElement.scrollTop;
       } else if (document.body) { // all other Explorers
@@ -632,7 +640,7 @@
 
       // Get where we should move content to
       var modalContent = $('#modalContent');
-      var mdcTop = wt + ( winHeight / 2 ) - ( modalContent.outerHeight() / 2);
+      var mdcTop = wt + Math.max((winHeight / 2) - (modalContent.outerHeight() / 2), 0);
       var mdcLeft = ( winWidth / 2 ) - ( modalContent.outerWidth() / 2);
 
       // Apply the changes

--- a/docroot/profiles/favrskov/modules/contrib/ctools/page_manager/page_manager.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/page_manager/page_manager.info
@@ -3,13 +3,11 @@ description = Provides a UI and API to manage pages within the site.
 core = 7.x
 dependencies[] = ctools
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 
 files[] = tests/head_links.test
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/page_manager/plugins/tasks/page.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/page_manager/plugins/tasks/page.inc
@@ -261,6 +261,7 @@ function page_manager_page_theme(&$items, $task) {
  *   creating named arguments in the path.
  */
 function page_manager_page_execute($subtask_id) {
+  $func_args = func_get_args();
   $page = page_manager_page_load($subtask_id);
   $task = page_manager_get_task($page->task);
   $subtask = page_manager_get_task_subtask($task, $subtask_id);
@@ -268,7 +269,7 @@ function page_manager_page_execute($subtask_id) {
   // Turn the contexts into a properly keyed array.
   $contexts = array();
   $args = array();
-  foreach (func_get_args() as $count => $arg) {
+  foreach ($func_args as $count => $arg) {
     if (is_object($arg) && get_class($arg) == 'ctools_context') {
       $contexts[$arg->id] = $arg;
       $args[] = $arg->original_argument;
@@ -430,7 +431,7 @@ function page_manager_page_save(&$page) {
 /**
  * Remove a page subtask.
  */
-function page_manager_page_delete($page) {
+function page_manager_page_delete($page, $skip_menu_rebuild = FALSE) {
   $task = page_manager_get_task($page->task);
   if ($function = ctools_plugin_get_function($task, 'delete')) {
     $function($page);
@@ -448,7 +449,11 @@ function page_manager_page_delete($page) {
   // rebuild this page again.
   ctools_include('export');
   ctools_export_load_object_reset('page_manager_pages');
-  menu_rebuild();
+  // Allow menu rebuild to be skipped when calling code is deleting multiple
+  // pages.
+  if (!$skip_menu_rebuild) {
+    menu_rebuild();
+  }
 }
 
 /**

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_attachments.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_attachments.inc
@@ -21,7 +21,7 @@ if (module_exists('upload')) {
 
 function ctools_node_form_attachments_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('Attach files');
   $block->delta = 'url-path-options';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_author.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_author.inc
@@ -17,7 +17,7 @@ $plugin = array(
 
 function ctools_node_form_author_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('Authoring information');
   $block->delta = 'author-options';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_book.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_book.inc
@@ -21,7 +21,7 @@ if (module_exists('book')) {
 
 function ctools_node_form_book_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('Book outline');
   $block->delta = 'book-outline';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_buttons.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_buttons.inc
@@ -17,7 +17,7 @@ $plugin = array(
 
 function ctools_node_form_buttons_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = '';
   $block->delta = 'buttons';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_comment.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_comment.inc
@@ -21,7 +21,7 @@ if (module_exists('comment')) {
 
 function ctools_node_form_comment_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('Comment options');
   $block->delta = 'comment-options';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_language.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_language.inc
@@ -17,7 +17,7 @@ $plugin = array(
 
 function ctools_node_form_language_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->delta = 'language-options';
 

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_log.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_log.inc
@@ -17,7 +17,7 @@ $plugin = array(
 
 function ctools_node_form_log_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
   $block->title = t('Revision information');
 
   if (isset($context->form)) {

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_menu.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_menu.inc
@@ -21,7 +21,7 @@ if (module_exists('menu')) {
 
 function ctools_node_form_menu_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('Menu options');
   $block->delta = 'menu-options';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_path.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_path.inc
@@ -21,7 +21,7 @@ if (module_exists('path')) {
 
 function ctools_node_form_path_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->title = t('URL path options');
   $block->delta = 'url-path-options';

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_publishing.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_publishing.inc
@@ -23,7 +23,7 @@ function ctools_node_form_publishing_content_type_render($subtype, $conf, $panel
   $block = new stdClass();
 
   $block->title = t('Publishing options');
-  $block->module = t('node_form');
+  $block->module = 'node_form';
   $block->delta = 'publishing-options';
 
   if (isset($context->form)) {

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_title.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/content_types/node_form/node_form_title.inc
@@ -17,7 +17,7 @@ $plugin = array(
 
 function ctools_node_form_title_content_type_render($subtype, $conf, $panel_args, &$context) {
   $block = new stdClass();
-  $block->module = t('node_form');
+  $block->module = 'node_form';
 
   $block->delta = 'title-options';
 

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/contexts/user.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/contexts/user.inc
@@ -152,6 +152,7 @@ function ctools_context_user_settings_form_submit($form, &$form_state) {
  */
 function ctools_context_user_convert_list() {
   $tokens = token_info();
+  $list = array();
   foreach ($tokens['tokens']['user'] as $id => $info) {
     if (!isset($list[$id])) {
       $list[$id] = $info['name'];

--- a/docroot/profiles/favrskov/modules/contrib/ctools/plugins/export_ui/ctools_export_ui.class.php
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/plugins/export_ui/ctools_export_ui.class.php
@@ -644,6 +644,7 @@ class ctools_export_ui {
   }
 
   public function add_page($js, $input, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('add'), PASS_THROUGH);
 
     // If a step not set, they are trying to create a new item. If a step
@@ -666,7 +667,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -681,6 +682,7 @@ class ctools_export_ui {
    * Main entry point to edit an item.
    */
   public function edit_page($js, $input, $item, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('edit', $item), PASS_THROUGH);
 
     // Check to see if there is a cached item to get if we're using the wizard.
@@ -702,7 +704,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -717,6 +719,7 @@ class ctools_export_ui {
    * Main entry point to clone an item.
    */
   public function clone_page($js, $input, $original, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('clone', $original), PASS_THROUGH);
 
     // If a step not set, they are trying to create a new clone. If a step
@@ -756,7 +759,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -1237,6 +1240,7 @@ class ctools_export_ui {
    * Page callback to import information for an exportable item.
    */
   public function import_page($js, $input, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('import'), PASS_THROUGH);
     // Import is basically a multi step wizard form, so let's go ahead and
     // use CTools' wizard.inc for it.
@@ -1261,7 +1265,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     // import always uses the wizard.

--- a/docroot/profiles/favrskov/modules/contrib/ctools/stylizer/stylizer.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/stylizer/stylizer.info
@@ -2,13 +2,11 @@ name = Stylizer
 description = Create custom styles for applications such as Panels.
 core = 7.x
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 dependencies[] = color
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/term_depth/term_depth.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/term_depth/term_depth.info
@@ -3,11 +3,9 @@ description = Controls access to context based upon term depth
 core = 7.x
 dependencies[] = ctools
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/tests/ctools_export_test/ctools_export_test.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/tests/ctools_export_test/ctools_export_test.info
@@ -2,15 +2,13 @@ name = CTools export test
 description = CTools export test module
 core = 7.x
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 dependencies[] = ctools
 hidden = TRUE
 
 files[] = ctools_export.test
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/tests/ctools_plugin_test.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/tests/ctools_plugin_test.info
@@ -1,14 +1,12 @@
 name = Chaos tools plugins test
 description = Provides hooks for testing ctools plugins.
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 core = 7.x
 dependencies[] = ctools
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/ctools/views_content/plugins/relationships/node_from_view.inc
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/views_content/plugins/relationships/node_from_view.inc
@@ -33,7 +33,7 @@ function views_content_node_from_view_context($context, $conf, $placeholder = FA
   views_content_context_get_output($context);
 
   $row = intval($conf['row']) - 1;
-  if (isset($view->result[$row])) {
+  if (isset($view->result[$row]) && isset($view->base_field) && isset($view->result[$row]->{$view->base_field})) {
     $nid = $view->result[$row]->{$view->base_field};
     if ($nid) {
       $node = node_load($nid);

--- a/docroot/profiles/favrskov/modules/contrib/ctools/views_content/views_content.info
+++ b/docroot/profiles/favrskov/modules/contrib/ctools/views_content/views_content.info
@@ -5,14 +5,12 @@ dependencies[] = ctools
 dependencies[] = views
 core = 7.x
 package = Chaos tool suite
-version = CTOOLS_MODULE_VERSION
 files[] = plugins/views/views_content_plugin_display_ctools_context.inc
 files[] = plugins/views/views_content_plugin_display_panel_pane.inc
 files[] = plugins/views/views_content_plugin_style_ctools_context.inc
 
-; Information added by Drupal.org packaging script on 2018-02-24
-version = "7.x-1.14"
+; Information added by Drupal.org packaging script on 2019-02-08
+version = "7.x-1.15"
 core = "7.x"
 project = "ctools"
-datestamp = "1519455788"
-
+datestamp = "1549603691"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_bean/rh_bean.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_bean/rh_bean.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = bean
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_field_collection/rh_field_collection.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_field_collection/rh_field_collection.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = field_collection
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_file/rh_file.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_file/rh_file.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = file_entity
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_node/rh_node.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_node/rh_node.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = node
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_node/rh_node.module
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_node/rh_node.module
@@ -116,3 +116,20 @@ function rh_node_node_type_delete($type) {
   // Delete variables connected to this content type.
   rabbit_hole_delete_variables('node', $type->type);
 }
+
+/**
+ * Implements hook_rabbit_hole_execute_alter() on behalf of colorbox_node.
+ */
+function colorbox_node_rabbit_hole_execute_alter(&$action, $context) {
+  if ($context['entity_type'] === 'node') {
+    // Version 7.x-3.x
+    $access = function_exists('colorbox_node_is_active') && colorbox_node_is_active();
+    // Version 7.x-3.5 and below.
+    $path = drupal_static('colorbox_original_q');
+    $access = $access || ($path && arg(0, $path) === 'colorbox');
+
+    if ($access) {
+      $action = FALSE;
+    }
+  }
+}

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_profile2/rh_profile2.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_profile2/rh_profile2.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = profile2_page
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_taxonomy/rh_taxonomy.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_taxonomy/rh_taxonomy.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = taxonomy
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_user/rh_user.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/modules/rh_user/rh_user.info
@@ -4,9 +4,8 @@ core = 7.x
 dependencies[] = rabbit_hole
 dependencies[] = user
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.api.php
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.api.php
@@ -32,3 +32,27 @@
      ),
    );
  }
+
+/**
+ * Alters the action before it is performed.
+ *
+ * @param $action
+ *   The action that will be performed. The following constants and values are
+ *   recognized:
+ *   - RABBIT_HOLE_ACCESS_DENIED: Return 403.
+ *   - RABBIT_HOLE_PAGE_NOT_FOUND:
+ *   - RABBIT_HOLE_PAGE_REDIRECT
+ *   - NULL or FALSE to skip the action.
+ * @param $context
+ *   An associative array containing:
+ *   - entity_type: The type of $entity; for example, 'node' or 'user'.
+ *   - entity: The entity that is being viewed.
+ */
+function hook_rabbit_hole_execute_alter(&$action, $context) {
+  if ($context['entity_type'] === 'user' && isset($_GET['token'])) {
+    $user = $context['entity'];
+    if (drupal_valid_token($_GET['token'], "override_rh:user:$user->uid")) {
+      $action = FALSE;
+    }
+  }
+}

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.info
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.info
@@ -2,9 +2,8 @@ name = Rabbit Hole
 description = Basic functionality that is shared among the different Rabbit Hole modules.
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2017-03-20
-version = "7.x-2.24"
+; Information added by Drupal.org packaging script on 2019-02-26
+version = "7.x-2.25"
 core = "7.x"
 project = "rabbit_hole"
-datestamp = "1490001791"
-
+datestamp = "1551214385"

--- a/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.module
+++ b/docroot/profiles/favrskov/modules/contrib/rabbit_hole/rabbit_hole.module
@@ -294,12 +294,14 @@ function rabbit_hole_form_validate($form, &$form_state) {
  *   something is done, this function will redirect the user immediately.
  */
 function rabbit_hole_execute($entity_type, $entity) {
-  // Exit early if the request is being loaded via AJAX.
-  if (!empty($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) == 'xmlhttprequest') {
-    return;
-  }
+  $action = rabbit_hole_get_action($entity_type, $entity);
+  $context = array(
+    'entity_type' => $entity_type,
+    'entity' => $entity
+  );
+  drupal_alter('rabbit_hole_execute', $action, $context);
 
-  switch (rabbit_hole_get_action($entity_type, $entity)) {
+  switch ($action) {
     case RABBIT_HOLE_ACCESS_DENIED:
       // Deliver a 403, and exit.
       drupal_access_denied();

--- a/docroot/profiles/minimal/minimal.info
+++ b/docroot/profiles/minimal/minimal.info
@@ -5,7 +5,7 @@ core = 7.x
 dependencies[] = block
 dependencies[] = dblog
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/profiles/standard/standard.info
+++ b/docroot/profiles/standard/standard.info
@@ -24,7 +24,7 @@ dependencies[] = field_ui
 dependencies[] = file
 dependencies[] = rdf
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_compatible_test/drupal_system_listing_compatible_test.info
@@ -6,7 +6,7 @@ core = 7.x
 hidden = TRUE
 files[] = drupal_system_listing_compatible_test.test
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
+++ b/docroot/profiles/testing/modules/drupal_system_listing_incompatible_test/drupal_system_listing_incompatible_test.info
@@ -8,7 +8,7 @@ version = VERSION
 core = 6.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/profiles/testing/testing.info
+++ b/docroot/profiles/testing/testing.info
@@ -4,7 +4,7 @@ version = VERSION
 core = 7.x
 hidden = TRUE
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/sites/default/default.settings.php
+++ b/docroot/sites/default/default.settings.php
@@ -479,6 +479,23 @@ ini_set('session.cookie_lifetime', 2000000);
 # $conf['block_cache_bypass_node_grants'] = TRUE;
 
 /**
+ * Expiration of cache_form entries:
+ *
+ * Drupal's Form API stores details of forms in cache_form and these entries are
+ * kept for at least 6 hours by default. Expired entries are cleared by cron.
+ * Busy sites can encounter problems with the cache_form table becoming very
+ * large. It's possible to mitigate this by setting a shorter expiration for
+ * cached forms. In some cases it may be desirable to set a longer cache
+ * expiration, for example to prolong cache_form entries for Ajax forms in
+ * cached HTML.
+ *
+ * @see form_set_cache()
+ * @see system_cron()
+ * @see ajax_get_form()
+ */
+# $conf['form_cache_expiration'] = 21600;
+
+/**
  * String overrides:
  *
  * To override specific strings on your site with or without enabling the Locale
@@ -628,3 +645,17 @@ $conf['404_fast_html'] = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
  * @see drupal_clean_css_identifier()
  */
 # $conf['allow_css_double_underscores'] = TRUE;
+
+/**
+ * The default list of directories that will be ignored by Drupal's file API.
+ *
+ * By default ignore node_modules and bower_components folders to avoid issues
+ * with common frontend tools and recursive scanning of directories looking for
+ * extensions.
+ *
+ * @see file_scan_directory()
+ */
+$conf['file_scan_ignore_directories'] = array(
+  'node_modules',
+  'bower_components',
+);

--- a/docroot/themes/bartik/bartik.info
+++ b/docroot/themes/bartik/bartik.info
@@ -34,7 +34,7 @@ regions[footer] = Footer
 settings[shortcut_module_link] = 0
 
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/themes/garland/garland.info
+++ b/docroot/themes/garland/garland.info
@@ -7,7 +7,7 @@ stylesheets[all][] = style.css
 stylesheets[print][] = print.css
 settings[garland_width] = fluid
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/themes/seven/seven.info
+++ b/docroot/themes/seven/seven.info
@@ -13,7 +13,7 @@ regions[page_bottom] = Page bottom
 regions[sidebar_first] = First sidebar
 regions_hidden[] = sidebar_first
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"

--- a/docroot/themes/stark/stark.info
+++ b/docroot/themes/stark/stark.info
@@ -5,7 +5,7 @@ version = VERSION
 core = 7.x
 stylesheets[all][] = layout.css
 
-; Information added by Drupal.org packaging script on 2019-01-16
-version = "7.63"
+; Information added by Drupal.org packaging script on 2019-02-06
+version = "7.64"
 project = "drupal"
-datestamp = "1547681965"
+datestamp = "1549481024"


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-82
  
### Changes
- Perform the pending updates for March 2019 for Drupal Core and contrib modules.
  
### Technical Details
- Manual updated of Drupal core from version 7.63 to 7.64 (patched)
- Apply core patch 1078878-DisableAutoCreation-D7-UTF-8.patch to core after manual update (link to issue in References)
- Apply core patch drupal-add_basic_svg_support-2539478-3-D7.patch to core after manual update (link to issue in References)
- Updated 'ctools' from version 7.x-1.14 to 7.x-1.15.
- Updated 'rabbit_hole' from version 7.x-2.24 to 7.x-2.25.

### Affected Pages
- Globally
  
### Key Affected Code
- N/A
  
### Key Functionality in custom code
- N/A
  
### References
- https://www.drupal.org/project/drupal/issues/1078878
- https://www.drupal.org/project/drupal/issues/2539478
  
### Notices
- N/A