### PR TITLE
FAVCS-99: "Apply date" missing from the jobfeed

### DIFF
--- a/docroot/profiles/favrskov/modules/custom/favrskov_helper/feeds_tamper_plugins/date_converter.inc
+++ b/docroot/profiles/favrskov/modules/custom/favrskov_helper/feeds_tamper_plugins/date_converter.inc
@@ -36,21 +36,13 @@ function favrskov_helper_plugin_date_to_proper_format_form($importer, $element_k
  * Callback that will be called during import on field that plugin was attached.
  */
 function favrskov_helper_plugin_date_to_proper_format_callback($result, $item_key, $element_key, &$field, $settings) {
-  $field =  strtotime(favrskov_helper_feeds_tamper_danish_month_to_english($field));
+
+  $current_local = locale_get_default();
+  setlocale(LC_ALL,"da_DK");
+  $date = DateTime::createFromFormat("d. M Y", $field);
+  $field = $date->getTimestamp();
+  // Restore default local.
+  setlocale(LC_ALL, $current_local);
+
 }
 
-function favrskov_helper_feeds_tamper_danish_month_to_english($str) {
-  $str = str_replace('januar', 'January', $str);
-  $str = str_replace('februar', 'February', $str);
-  $str = str_replace('marts', 'March', $str);
-  $str = str_replace('april', 'April', $str);
-  $str = str_replace('maj', 'May', $str);
-  $str = str_replace('juni', 'June', $str);
-  $str = str_replace('juli', 'July', $str);
-  $str = str_replace('august', 'August', $str);
-  $str = str_replace('september', 'September', $str);
-  $str = str_replace('oktober', 'October', $str);
-  $str = str_replace('november', 'November', $str);
-  $str = str_replace('december', 'December', $str);
-  return $str;
-}

--- a/docroot/profiles/favrskov/modules/custom/favrskov_helper/feeds_tamper_plugins/date_converter.inc
+++ b/docroot/profiles/favrskov/modules/custom/favrskov_helper/feeds_tamper_plugins/date_converter.inc
@@ -36,8 +36,21 @@ function favrskov_helper_plugin_date_to_proper_format_form($importer, $element_k
  * Callback that will be called during import on field that plugin was attached.
  */
 function favrskov_helper_plugin_date_to_proper_format_callback($result, $item_key, $element_key, &$field, $settings) {
-  $date       = new DateTime($field);
-  $timestamp  = $date->getTimestamp();
+  $field =  strtotime(favrskov_helper_feeds_tamper_danish_month_to_english($field));
+}
 
-  $field = format_date($timestamp, $settings['type']);
+function favrskov_helper_feeds_tamper_danish_month_to_english($str) {
+  $str = str_replace('januar', 'January', $str);
+  $str = str_replace('februar', 'February', $str);
+  $str = str_replace('marts', 'March', $str);
+  $str = str_replace('april', 'April', $str);
+  $str = str_replace('maj', 'May', $str);
+  $str = str_replace('juni', 'June', $str);
+  $str = str_replace('juli', 'July', $str);
+  $str = str_replace('august', 'August', $str);
+  $str = str_replace('september', 'September', $str);
+  $str = str_replace('oktober', 'October', $str);
+  $str = str_replace('november', 'November', $str);
+  $str = str_replace('december', 'December', $str);
+  return $str;
 }

--- a/docroot/profiles/favrskov/modules/features/other/feeds_job_importer/feeds_job_importer.feeds_tamper_default.inc
+++ b/docroot/profiles/favrskov/modules/features/other/feeds_job_importer/feeds_job_importer.feeds_tamper_default.inc
@@ -42,5 +42,19 @@ function feeds_job_importer_feeds_tamper_default() {
   $feeds_tamper->description = 'Convert date during export to format used on Favrskov site';
   $export['job_importer-start_date-date_converter'] = $feeds_tamper;
 
+  $feeds_tamper = new stdClass();
+  $feeds_tamper->disabled = FALSE; /* Edit this to true to make a default feeds_tamper disabled initially */
+  $feeds_tamper->api_version = 2;
+  $feeds_tamper->id = 'job_importer-xpathparser_6-date_converter';
+  $feeds_tamper->importer = 'job_importer';
+  $feeds_tamper->source = 'xpathparser:6';
+  $feeds_tamper->plugin_id = 'date_converter';
+  $feeds_tamper->settings = array(
+    'type' => 'medium',
+  );
+  $feeds_tamper->weight = 0;
+  $feeds_tamper->description = 'Convert date during export to format used on Favrskov site';
+  $export['job_importer-xpathparser_6-date_converter'] = $feeds_tamper;
+
   return $export;
 }

--- a/docroot/profiles/favrskov/modules/features/other/feeds_job_importer/feeds_job_importer.info
+++ b/docroot/profiles/favrskov/modules/features/other/feeds_job_importer/feeds_job_importer.info
@@ -14,3 +14,4 @@ features[features_api][] = api:2
 features[feeds_importer][] = job_importer
 features[feeds_tamper][] = job_importer-description-find_replace_regex
 features[feeds_tamper][] = job_importer-start_date-date_converter
+features[feeds_tamper][] = job_importer-xpathparser_6-date_converter


### PR DESCRIPTION
### https://ffwagency.atlassian.net/browse/FAVCS-99
  
### Changes
- Translate date months from Danish to English
  
### Technical Details
- Add custom tamper to convert dates from Danish to English
- Add tamper to 'deadline' field and export feature
  
### Affected Pages
- /job
  
### Key Affected Code
- docroot/profiles/favrskov/modules/custom/favrskov_helper/feeds_tamper_plugins/date_converter.inc
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- After deploye run: `drush fr feeds_job_importer`