### PR TITLE
FAVCS-135: Updates, November 2019.

### DIFF
--- a/docroot/profiles/favrskov/modules/contrib/apachesolr_views/apachesolr_views.info
+++ b/docroot/profiles/favrskov/modules/contrib/apachesolr_views/apachesolr_views.info
@@ -19,8 +19,8 @@ files[] = handlers/apachesolr_views_handler_filter_string.inc
 files[] = handlers/apachesolr_views_keyword_handler_filter.inc
 files[] = handlers/apachesolr_views_handler_argument.inc
 
-; Information added by Drupal.org packaging script on 2019-08-15
-version = "7.x-1.1-beta2"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-1.1-beta3"
 core = "7.x"
 project = "apachesolr_views"
-datestamp = "1565842084"
+datestamp = "1572527312"

--- a/docroot/profiles/favrskov/modules/contrib/apachesolr_views/handlers/apachesolr_views_handler_filter_string.inc
+++ b/docroot/profiles/favrskov/modules/contrib/apachesolr_views/handlers/apachesolr_views_handler_filter_string.inc
@@ -28,7 +28,7 @@ class apachesolr_views_handler_filter_string extends views_handler_filter_string
     if ($this->operator == '!=') {
       $this->real_field = '-' . $this->real_field;
     }
-    $this->query->add_where($this->options['group'], $this->real_field, '"' . htmlspecialchars($this->value, ENT_QUOTES) . '"');
+    $this->query->add_where($this->options['group'], $this->real_field, $this->value);
   }
 
   /**

--- a/docroot/profiles/favrskov/modules/contrib/media/includes/media.fields.inc
+++ b/docroot/profiles/favrskov/modules/contrib/media/includes/media.fields.inc
@@ -279,7 +279,7 @@ function media_field_widget_process($element, &$form_state, $form) {
       '#default_value' => isset($item['alt']) ? $item['alt'] : '',
       '#description' => t('This text will be used by screen readers, search engines, or when the image cannot be loaded.<br />
 <em>(Notice: this field is not fetched on -all- formatters yet. For example: If the Rendered file formatter will be used, this field is not available at the moment.)</em>'),
-      '#maxlength' => variable_get('image_alt_length', 80),
+      '#maxlength' => variable_get('image_alt_length', 100),
       '#weight' => 1,
     );
   }

--- a/docroot/profiles/favrskov/modules/contrib/media/media.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/media.info
@@ -24,8 +24,8 @@ configure = admin/config/media/browser
 ; We have to add a fake version so Git checkouts do not fail Media dependencies
 version = 7.x-2.x-dev
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_bulk_upload/media_bulk_upload.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_bulk_upload/media_bulk_upload.info
@@ -15,8 +15,8 @@ test_dependencies[] = plupload
 files[] = includes/MediaBrowserBulkUpload.inc
 files[] = tests/media_bulk_upload.test
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_internet/media_internet.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_internet/media_internet.info
@@ -12,8 +12,8 @@ files[] = includes/MediaInternetNoHandlerException.inc
 files[] = includes/MediaInternetValidationException.inc
 files[] = tests/media_internet.test
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_internet/tests/media_internet_test.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_internet/tests/media_internet_test.info
@@ -7,8 +7,8 @@ hidden = TRUE
 files[] = includes/MediaInternetTestStreamWrapper.inc
 files[] = includes/MediaInternetTestHandler.inc
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_migrate_file_types/media_migrate_file_types.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_migrate_file_types/media_migrate_file_types.info
@@ -8,8 +8,8 @@ dependencies[] = media
 
 configure = admin/structure/file-types/upgrade
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_wysiwyg/media_wysiwyg.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_wysiwyg/media_wysiwyg.info
@@ -16,8 +16,8 @@ files[] = tests/media_wysiwyg.paragraph_fix_filter.test
 
 configure = admin/config/media/browser
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/media_wysiwyg_view_mode/media_wysiwyg_view_mode.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/media_wysiwyg_view_mode/media_wysiwyg_view_mode.info
@@ -3,8 +3,8 @@ description = DEPRECATED, this folder is only here so that the module can be uni
 package = Media
 core = 7.x
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/modules/mediafield/mediafield.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/modules/mediafield/mediafield.info
@@ -4,8 +4,8 @@ package = Media
 core = 7.x
 dependencies[] = media
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"

--- a/docroot/profiles/favrskov/modules/contrib/media/tests/media_module_test.info
+++ b/docroot/profiles/favrskov/modules/contrib/media/tests/media_module_test.info
@@ -6,8 +6,8 @@ hidden = TRUE
 
 files[] = includes/MediaModuleTest.inc
 
-; Information added by Drupal.org packaging script on 2019-07-15
-version = "7.x-2.23"
+; Information added by Drupal.org packaging script on 2019-10-31
+version = "7.x-2.24"
 core = "7.x"
 project = "media"
-datestamp = "1563204686"
+datestamp = "1572552486"


### PR DESCRIPTION
### Jira link
https://ffwagency.atlassian.net/browse/FAVCS-135

### Changes
- Updated `media` from version 7.x-2.23 to 7.x-2.24. [Release note](https://www.drupal.org/project/media/releases/7.x-2.24)
- Updated `apachesolr_views` from version 7.x-1.1-beta2 to 7.x-1.1-beta3. [Release note](https://www.drupal.org/project/apachesolr_views/releases/7.x-1.1-beta3)
