### PR TITLE
FAVCS-145: Fix url stripping in call to action buttons.

### DIFF
--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/bannerlink/node--bannerlink.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/bannerlink/node--bannerlink.tpl.php
@@ -12,7 +12,7 @@ $text .= '<span class="banner-link-icon">';
 $text .= '</span>';
 $text .= '<span class="require-type"></span>';
 
-print l($text, $link['url'], array(
+print l($text, $link['original_url'], array(
   'html' => TRUE,
   'attributes' => array(
     'title' => empty($content['field_image_alt_text'][0]['#markup']) ? '' : $content['field_image_alt_text'][0]['#markup'],

--- a/docroot/profiles/favrskov/themes/favrskovtheme/template/node/self_service/node--self-service.tpl.php
+++ b/docroot/profiles/favrskov/themes/favrskovtheme/template/node/self_service/node--self-service.tpl.php
@@ -12,7 +12,7 @@ $text = render($content['field_displayed_title']);
 $text .= render($content['field_teaser']);
 $text .= '<span class="require-type"></span>';
 
-print l($text, $link['url'], array(
+print l($text, $link['original_url'], array(
   'html' => TRUE,
   'attributes' => array(
     'title' => $content['field_image_alt_text'][0]['#markup'],


### PR DESCRIPTION
## https://ffwagency.atlassian.net/browse/FAVCS-145
  
### Changes
- Fix url stripping in call to action buttons.
  
### Technical Details
- Change url to original url to prevent the stripping
  
### Affected Pages
- /borger/pas-og-koerekort/bestil-pas
  
### Key Affected Code
- docroot/profiles/favrskov/themes/favrskovtheme/template/node/self_service/node--self-service.tpl.php
  
### Key Functionality in custom code
- N/A
  
### References
- N/A
  
### Notices
- N/A
